### PR TITLE
CI: fix pip install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - source activate $CONDA_ENV
 
 install:
-  - NOLIBCA=1 pip install --no-binary pyepics
+  - "NOLIBCA=1 pip install --no-binary :all: pyepics"
   - conda install epics-base
   - pip install pytest pytest-cov codecov graphviz pygraphviz parsimonious attrs networkx prettytable pandas numpy ipython
   - 'pip install https://github.com/NSLS-II/ophyd/zipball/master#egg=ophyd'


### PR DESCRIPTION
This PR will unblock the testing by correcting the `pip install pyepics` command (the testing may still fail).